### PR TITLE
JWT token auth bitches

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'mongoid', '~> 6.0.0'
 # memcache for sessions
 gem 'dalli'
 
+gem 'jwt'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,7 @@ DEPENDENCIES
   byebug
   dalli
   factory_girl_rails
+  jwt
   listen (~> 3.0.5)
   mongoid (~> 6.0.0)
   mongoid-rspec

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,5 @@
 class ApplicationController < ActionController::API
 
-  HMAC_SECRET = ENV['JWT_HMAC_SECRET']
-
   # TODO implement more specific error handling
   # https://github.com/jwt/ruby-jwt/blob/master/lib/jwt/error.rb
 
@@ -14,7 +12,7 @@ class ApplicationController < ActionController::API
   end
 
   def decoded_token
-    decoded_tok = JWT.decode raw_jwt_token_str, HMAC_SECRET, true, { algorithm: 'HS256' }
+    decoded_tok = JWT.decode raw_jwt_token_str, Rails.application.config.JWT_HMAC_SECRET, true, { algorithm: 'HS256' }
     return { payload: decoded_tok[0], header: decoded_tok[1] }.deep_symbolize_keys!
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,41 +2,45 @@ class ApplicationController < ActionController::API
 
   HMAC_SECRET = ENV['JWT_HMAC_SECRET']
 
+  # TODO implement more specific error handling
+  # https://github.com/jwt/ruby-jwt/blob/master/lib/jwt/error.rb
+
+  # [ {"data"=>"test"}, # payload
+  #   {"typ"=>"JWT", "alg"=>"whatever"} # header ]
+
+  def raw_jwt_token_str
+    # remove leading 'Bearer'
+    request.headers['Authorization']&.sub(/^Bearer /, '')
+  end
+
+  def decoded_token
+    decoded_tok = JWT.decode raw_jwt_token_str, HMAC_SECRET, true, { algorithm: 'HS256' }
+    return { payload: decoded_tok[0], header: decoded_tok[1] }.deep_symbolize_keys!
+  end
+
   def current_user_hash
-    byebug
-    token = request.headers['Authorization'].sub(/^Bearer /, '') # remove leading 'Bearer'
     begin
-      decoded_token = JWT.decode token, HMAC_SECRET, true, { algorithm: 'HS256' }
+      return decoded_token[:payload][:user]
     rescue JWT::ExpiredSignature
       render json: { error: 'Session has expired' }, status: 403
-    rescue JWT::DecodeError => e
-      # https://github.com/jwt/ruby-jwt/blob/master/lib/jwt/error.rb
+    rescue JWT::DecodeError
       head :unauthorized
       return nil
     end
-    byebug
-    # Array
-    # [
-    #   {"data"=>"test"}, # payload
-    #   {"typ"=>"JWT", "alg"=>"none"} # header
-    # ]
-    # TODO check against logged_out db
-    payload = decoded_token[0]
-    return payload['user']
   end
 
   def user_authorized?
-    byebug
-    token = request.headers['Authorization'].sub(/^Bearer /, '') # remove leading 'Bearer'
     begin
-      # just check decode successful
-      JWT.decode token, HMAC_SECRET, true, { algorithm: 'HS256' }
-    rescue JWT::DecodeError => e
+      # just check token exists, decode successful, and user not logged out
+      !raw_jwt_token_str.nil? and !decoded_token.nil? and !Rails.application.config.logout_memcached_client.get(raw_jwt_token_str)
+    rescue JWT::ExpiredSignature
+      render json: { error: 'Session has expired' }, status: 403
+      false
+    rescue JWT::DecodeError
       # https://github.com/jwt/ruby-jwt/blob/master/lib/jwt/error.rb
       head :unauthorized
-      return false
+      false
     end
-    return true
   end
 
   def ensure_user_authorized

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,42 @@
 class ApplicationController < ActionController::API
 
-  def current_user
-    session[:current_user]
+  HMAC_SECRET = ENV['JWT_HMAC_SECRET']
+
+  def current_user_hash
+    byebug
+    token = request.headers['Authorization'].sub(/^Bearer /, '') # remove leading 'Bearer'
+    begin
+      decoded_token = JWT.decode token, HMAC_SECRET, true, { algorithm: 'HS256' }
+    rescue JWT::ExpiredSignature
+      render json: { error: 'Session has expired' }, status: 403
+    rescue JWT::DecodeError => e
+      # https://github.com/jwt/ruby-jwt/blob/master/lib/jwt/error.rb
+      head :unauthorized
+      return nil
+    end
+    byebug
+    # Array
+    # [
+    #   {"data"=>"test"}, # payload
+    #   {"typ"=>"JWT", "alg"=>"none"} # header
+    # ]
+    # TODO check against logged_out db
+    payload = decoded_token[0]
+    return payload['user']
   end
 
   def user_authorized?
-    current_user&.id != nil
+    byebug
+    token = request.headers['Authorization'].sub(/^Bearer /, '') # remove leading 'Bearer'
+    begin
+      # just check decode successful
+      JWT.decode token, HMAC_SECRET, true, { algorithm: 'HS256' }
+    rescue JWT::DecodeError => e
+      # https://github.com/jwt/ruby-jwt/blob/master/lib/jwt/error.rb
+      head :unauthorized
+      return false
+    end
+    return true
   end
 
   def ensure_user_authorized

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,6 +2,6 @@ class ProjectsController < ApplicationController
   before_action :ensure_user_authorized
 
   def index
-    render json:  Project.all
+    render json:  Project.where(owner_id: current_user_hash[:id])
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,12 @@
 # This class facilitates oauth2 authentication. successful oauth callbacks redirect to #create,
 # where the session is created with the information of the associated user in our db (which is created if necessary).
 
+require 'jwt'
+require 'dalli'
+
 class SessionsController < ApplicationController
+
+  HMAC_SECRET = ENV['JWT_HMAC_SECRET']
 
   def create
     @user = User.where(provider: auth_hash[:provider], oauth_uid: auth_hash[:uid]).first
@@ -9,8 +14,15 @@ class SessionsController < ApplicationController
       @user = User.create(provider: auth_hash[:provider], oauth_uid: auth_hash[:uid], name: auth_hash[:info][:name], email: auth_hash[:info][:email], username: auth_hash[:info][:email])
     end
     if @user&.id != nil
-      session[:current_user] = @user
-      render json: @user
+      byebug
+      # create and return a json web token. disregard any session bullshit
+      payload = { user: @user.as_json, exp: (DateTime.now + 5.minutes).to_i }
+      token = JWT.encode payload, HMAC_SECRET, 'HS256'
+      # delete session_id cookie leftover from oauth
+      # cookies.delete
+      byebug
+      # return jwt
+      render json: token
     else
       head :not_found
     end
@@ -18,7 +30,8 @@ class SessionsController < ApplicationController
 
 
   def destroy
-    session[:current_user] = @user = nil
+    # TODO: add token to a different memcache namespace with expires = tok.valid_until, data: {disabled: true}
+    # and check this in app controller is valid etc
   end
 
   protected def auth_hash

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,12 +1,11 @@
 # This class facilitates oauth2 authentication. successful oauth callbacks redirect to #create,
-# where the session is created with the information of the associated user in our db (which is created if necessary).
-
-require 'jwt'
-require 'dalli'
+# where the jwt token is created with the information of the associated user in our db (which is created if necessary).
 
 class SessionsController < ApplicationController
 
   HMAC_SECRET = ENV['JWT_HMAC_SECRET']
+
+  before_action :ensure_user_authorized, except: [:create, :auth_hash]
 
   def create
     @user = User.where(provider: auth_hash[:provider], oauth_uid: auth_hash[:uid]).first
@@ -14,14 +13,9 @@ class SessionsController < ApplicationController
       @user = User.create(provider: auth_hash[:provider], oauth_uid: auth_hash[:uid], name: auth_hash[:info][:name], email: auth_hash[:info][:email], username: auth_hash[:info][:email])
     end
     if @user&.id != nil
-      byebug
-      # create and return a json web token. disregard any session bullshit
+      # create and return a json web token.
       payload = { user: @user.as_json, exp: (DateTime.now + 5.minutes).to_i }
       token = JWT.encode payload, HMAC_SECRET, 'HS256'
-      # delete session_id cookie leftover from oauth
-      # cookies.delete
-      byebug
-      # return jwt
       render json: token
     else
       head :not_found
@@ -30,8 +24,13 @@ class SessionsController < ApplicationController
 
 
   def destroy
-    # TODO: add token to a different memcache namespace with expires = tok.valid_until, data: {disabled: true}
-    # and check this in app controller is valid etc
+    begin
+      byebug
+      Rails.application.config.logout_memcached_client.set(raw_jwt_token_str, true)
+      Rails.application.config.logout_memcached_client.touch(raw_jwt_token_str, decoded_token[:payload][:exp])
+    rescue JWT::DecodeError
+      head :unauthorized
+    end
   end
 
   protected def auth_hash

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,11 +3,10 @@
 
 class SessionsController < ApplicationController
 
-  HMAC_SECRET = ENV['JWT_HMAC_SECRET']
-
   before_action :ensure_user_authorized, except: [:create, :auth_hash]
 
   def create
+    byebug
     @user = User.where(provider: auth_hash[:provider], oauth_uid: auth_hash[:uid]).first
     if @user&.id.nil? # create user if not exist
       @user = User.create(provider: auth_hash[:provider], oauth_uid: auth_hash[:uid], name: auth_hash[:info][:name], email: auth_hash[:info][:email], username: auth_hash[:info][:email])
@@ -15,7 +14,7 @@ class SessionsController < ApplicationController
     if @user&.id != nil
       # create and return a json web token.
       payload = { user: @user.as_json, exp: (DateTime.now + 5.minutes).to_i }
-      token = JWT.encode payload, HMAC_SECRET, 'HS256'
+      token = JWT.encode payload, Rails.application.config.JWT_HMAC_SECRET, 'HS256'
       render json: token
     else
       head :not_found

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,6 @@ class SessionsController < ApplicationController
   before_action :ensure_user_authorized, except: [:create, :auth_hash]
 
   def create
-    byebug
     @user = User.where(provider: auth_hash[:provider], oauth_uid: auth_hash[:uid]).first
     if @user&.id.nil? # create user if not exist
       @user = User.create(provider: auth_hash[:provider], oauth_uid: auth_hash[:uid], name: auth_hash[:info][:name], email: auth_hash[:info][:email], username: auth_hash[:info][:email])
@@ -24,7 +23,6 @@ class SessionsController < ApplicationController
 
   def destroy
     begin
-      byebug
       Rails.application.config.logout_memcached_client.set(raw_jwt_token_str, true)
       Rails.application.config.logout_memcached_client.touch(raw_jwt_token_str, decoded_token[:payload][:exp])
     rescue JWT::DecodeError

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,8 @@
 class Project < ApplicationRecord
   has_one :song
 
+  belongs_to :user, foreign_key: :owner_id
+
   after_save :init_metadata
   after_destroy :destroy_metadata
 
@@ -10,10 +12,10 @@ class Project < ApplicationRecord
   end
 
   def destroy_metadata
-    ProjectMetadata.where(project_id: self.id).first.destroy
+    ProjectMetadata.find_by(project_id: self.id).destroy
   end
 
   def project_metadata
-    ProjectMetadata.where(project_id: self.id).first
+    ProjectMetadata.find_by(project_id: self.id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
   # todo reflect this constraint in a migration
   ##    add_index :table_name, [:field1, ... , :fieldn], unique: true
   validates :provider, uniqueness: {scope: :oauth_uid} # provider, uid pair must be unique
+
+  has_many :projects, foreign_key: :owner_id
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,4 +45,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  # set jwt secret from env
+  config.JWT_HMAC_SECRET = ENV['JWT_HMAC_SECRET']
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,5 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,4 +75,8 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # set jwt secret from env
+  config.JWT_HMAC_SECRET = ENV['JWT_HMAC_SECRET']
+
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # hmac key for test
+  config.JWT_HMAC_SECRET = 'poop'
 end

--- a/config/initializers/logout_memcached.rb
+++ b/config/initializers/logout_memcached.rb
@@ -1,0 +1,3 @@
+# initialize the dalli client for memcached logouts db
+# this port should be set in configuration and tied to whatever task ensures memcached is running..
+Rails.application.config.logout_memcached_client = Dalli::Client.new('localhost:11211', { namespace: "netjam/#{Rails.env}/jwt_logouts", compress: true })

--- a/db/migrate/20161019004913_add_proj_owner.rb
+++ b/db/migrate/20161019004913_add_proj_owner.rb
@@ -1,0 +1,6 @@
+class AddProjOwner < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :owner_id, :integer
+    add_foreign_key :projects, :users, column: :owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161016044305) do
+ActiveRecord::Schema.define(version: 20161019004913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,7 +22,8 @@ ActiveRecord::Schema.define(version: 20161016044305) do
   end
 
   create_table "projects", force: :cascade do |t|
-    t.string "name"
+    t.string  "name"
+    t.integer "owner_id"
   end
 
   create_table "songs", force: :cascade do |t|
@@ -43,5 +44,6 @@ ActiveRecord::Schema.define(version: 20161016044305) do
 
   add_foreign_key "clips", "projects"
   add_foreign_key "clips", "users"
+  add_foreign_key "projects", "users", column: "owner_id"
   add_foreign_key "songs", "projects"
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,5 +55,25 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  # factories
   require 'support/factory_girl'
+
+  # omniauth
+  OmniAuth.config.test_mode = true
+  # provider: auth_hash[:provider], oauth_uid: auth_hash[:uid], name: auth_hash[:info][:name], email: auth_hash[:info][:email], username: auth_hash[:info][:email])
+  OmniAuth.config.mock_auth[:google_oauth2] =
+    OmniAuth::AuthHash.new({
+                             'provider' => 'google_oauth2',
+                             'uid' => '123545',
+                             'info' => {
+                               'name' => 'mockuser',
+                               'image' => 'mock_user_thumbnail_url',
+                               'email' => 'mock@user.com'
+                             },
+                             'credentials' => {
+                               'token' => 'mock_token',
+                               'secret' => 'mock_secret'
+                             }
+                           })
+
 end

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+
+RSpec.describe "Auth", type: :request do
+  before do
+    Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:google_oauth2]
+  end
+
+  describe "Authorization" do
+    it "gets auth" do
+      get '/auth/google_oauth2/callback'
+      byebug
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/auth_spec.rb
+++ b/spec/requests/auth_spec.rb
@@ -7,10 +7,35 @@ RSpec.describe "Auth", type: :request do
   end
 
   describe "Authorization" do
-    it "gets auth" do
-      get '/auth/google_oauth2/callback'
-      byebug
-      expect(response).to have_http_status(200)
+    let(:resp_body) { JSON.parse(response.body)}
+    context 'can get token' do
+      it "gets auth" do
+        get '/auth/google_oauth2/callback'
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'using token on projects controller' do
+      before(:each) {
+        get '/auth/google_oauth2/callback'
+        @tok = response.body
+      }
+      it 'fails with no token' do
+        get '/api/projects'
+        expect(response).to have_http_status(401)
+      end
+
+      it 'succeeds with good token' do
+        get '/api/projects', headers: {Authorization: @tok}
+        expect(response).to have_http_status(200)
+      end
+
+      it 'can logout' do
+        get '/api/logout', headers: {Authorization: @tok}
+        expect(response).to have_http_status(204)
+        get '/api/projects', headers: {Authorization: @tok}
+        expect(response).to have_http_status(401)
+      end
     end
   end
 end


### PR DESCRIPTION
switch from cookie-based sessions to using a JSON Web Token, which is a signed and encrypted json object with our information in it (and a TTL). Basically we auth with oauth as usual, and then compute and return this token to the client and forget about it. When we get a request, we validate the Authenticate header's contents which should be a valid token (signed by us, not expired, etc), and use its data to perform the request, i.e. what user is asking for stuff. 

this complicated signout slightly as we have no way of guaranteeing that the client will discard the token, so we have to have a db of logged_out tokens. this is implemented with memcached.
